### PR TITLE
Read npm registry URL from ~/.npmrc

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const isUrl = require('is-url');
 const path = require('path');
 const Promise = require('bluebird');
 const tmp = require('tmp');
+const registryUrl = require('registry-url');
 
 Promise.promisifyAll(tmp);
 
@@ -17,7 +18,7 @@ Promise.promisifyAll(archive);
 
 const SEMVER = /^(?=\d)((x|\d+)\.?){1,}$/;
 
-let registry = 'https://registry.npmjs.org/';
+let registry = registryUrl();
 
 const createTmp = function(url) {
 	return tmp.dirAsync(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "list-npm-contents",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "List the contents of an npm package",
   "license": "MIT",
   "repository": "natecavanaugh/list-npm-contents",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "is-url": "^1.2.2",
     "ls-archive": "^1.2.3",
     "meow": "^3.3.0",
+    "registry-url": "^4.0.0",
     "tmp": "0.0.31"
   },
   "devDependencies": {


### PR DESCRIPTION
Hello,

The NPM registry URL is currently hard-coded in **index.js** which is a showstopper for when it's necessary to use a custom NPM registry.

This PR fixes the issue by adding a dependency to [`sindresorhus/registry-url`](https://github.com/sindresorhus/registry-url) and retrieving the URL through that module instead of using the hard-coded value.

PS: Failing tests have nothing to do with my changes. Btw, running Mocha tests manually succeeds.